### PR TITLE
Add engine option to override .ext jstransform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ test/fixtures/*/build
 
 # Coverage reports
 /coverage
+
+# OSX
+**/.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 2.1.?? - March 15, 2018
+* returned `engine` option 'cos it's a really good idea
+
 ### 2.1.0 - January 25, 2018
 * add a documentation link to the error messages
 * add debug for better debugging

--- a/README.md
+++ b/README.md
@@ -87,6 +87,21 @@ Only files that match this pattern will be processed. So this `metalsmith.json`:
 
 Would process all files that have the `.html` extension. Beware that the extensions might be changed by other plugins in the build chain, preventing the pattern from matching. We use [multimatch](https://github.com/sindresorhus/multimatch) for the pattern matching.
 
+### `engine`
+
+Use this to specify which jstransformer should be use regardless of the .ext type.  This allows for example, `mustache` engine with `.html` layouts.
+
+```json
+{
+  "plugins": {
+    "metalsmith-layouts": {
+      "engine": "mustache"
+    }
+  }
+}
+```
+
+
 ### `engineOptions`
 
 Use this to pass options to the jstransformer that's rendering your templates. So this `metalsmith.json`:

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,12 +11,12 @@ const toTransformer = require('inputformat-to-jstransformer');
 
 const cache = {};
 
-function getTransformer(ext) {
+function getTransformer(ext, settings) {
   if (ext in cache) {
     return cache[ext];
   }
 
-  const transformer = toTransformer(ext);
+  const transformer = toTransformer(settings.engine || ext);
   cache[ext] = transformer ? jstransformer(transformer) : false;
 
   return cache[ext];
@@ -98,7 +98,7 @@ function validate({ filename, files, settings }) {
 
   // Files without an applicable jstransformer are ignored
   const extension = layout.split('.').pop();
-  const transformer = getTransformer(extension);
+  const transformer = getTransformer(extension, settings);
 
   if (!transformer) {
     debug(`validation failed, no jstransformer found for layout for ${filename}`);

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -300,4 +300,21 @@ describe('metalsmith-layouts', () => {
       return done();
     });
   });
+
+  it('should allow engine to be explicitly specified and override extension', done => {
+    const base = path.join(process.cwd(), 'test', 'fixtures', 'override-engine');
+    const actual = path.join(base, 'build');
+    const expected = path.join(base, 'expected');
+    const metalsmith = new Metalsmith(base);
+
+    rimraf.sync(actual);
+
+    return metalsmith.use(plugin({ default: 'standard.html', engine: 'handlebars' })).build(err => {
+      if (err) {
+        return done(err);
+      }
+      expect(() => equal(actual, expected)).not.toThrow();
+      return done();
+    });
+  });
 });

--- a/test/fixtures/override-engine/expected/about.html
+++ b/test/fixtures/override-engine/expected/about.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+  <head></head>
+  <body>
+    <h1>The title</h1>
+
+  </body>
+</html>

--- a/test/fixtures/override-engine/expected/index.html
+++ b/test/fixtures/override-engine/expected/index.html
@@ -1,0 +1,1 @@
+<h1>The title</h1>

--- a/test/fixtures/override-engine/layouts/standard.html
+++ b/test/fixtures/override-engine/layouts/standard.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+  <head></head>
+  <body>
+    {{{ contents }}}
+  </body>
+</html>

--- a/test/fixtures/override-engine/src/about.html
+++ b/test/fixtures/override-engine/src/about.html
@@ -1,0 +1,1 @@
+<h1>The title</h1>

--- a/test/fixtures/override-engine/src/index.html
+++ b/test/fixtures/override-engine/src/index.html
@@ -1,0 +1,4 @@
+---
+layout: false
+---
+<h1>The title</h1>


### PR DESCRIPTION
Removing the `engine` option in 2.0.0 broke my build process and
it is nice to have the flexibility to specify engines regardless
of the file extension.